### PR TITLE
Added support for slices.

### DIFF
--- a/deepcopier.go
+++ b/deepcopier.go
@@ -207,6 +207,14 @@ func (dc *DeepCopier) SetFieldValue(entity interface{}, name string, value refle
 		}
 	}
 
+	// Slices
+	if kind == reflect.Slice {
+		if err := reflections.SetField(entity, name, value.Interface()); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	// Reflect
 	switch kind {
 	case reflect.Int8:

--- a/deepcopier_test.go
+++ b/deepcopier_test.go
@@ -69,6 +69,23 @@ func TestCopyFrom(t *testing.T) {
 	assert.Equal(t, expected.AnUInt64, userCopy.UInt64)
 }
 
+func TestSlices(t *testing.T) {
+	user := &User{
+		StringSlice: []string{"Chuck", "Norris"},
+		IntSlice:    []int{0, 8, 15},
+	}
+
+	userTo := &User{}
+	err := Copy(user).To(userTo)
+	if assert.NoError(t, err) {
+		assert.Equal(t, user.StringSlice, userTo.StringSlice)
+		assert.Equal(t, user.IntSlice, userTo.IntSlice)
+
+		user.StringSlice = []string{"hello", "world"}
+		assert.NotEqual(t, user.StringSlice, userTo.StringSlice)
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Fixtures
 // -----------------------------------------------------------------------------
@@ -88,6 +105,9 @@ type User struct {
 	AnUInt16 uint16
 	AnUInt32 uint32
 	AnUInt64 uint64
+
+	StringSlice []string
+	IntSlice    []int
 }
 
 func NewUser(now time.Time) *User {


### PR DESCRIPTION
When trying out deepcopier, I soon found out that slices don't seem to be supported. This PR aims to provide that functionality, though I am far from being a Golang reflection master.

I looked at deepcopier_test.go, but weren't sure if I understand the test code correctly. For example,
`TestCopyTo`copies from `user` to `userCopy` and I had expected the assertions to verify just that. However, the test verifies that `user` (the source of the operation) had the `expected` value. So I wrote my own test case.
