### PR TITLE
In the case that source type is pointer, its values is copied to destination.

### DIFF
--- a/deepcopier.go
+++ b/deepcopier.go
@@ -306,6 +306,7 @@ func (dc *DeepCopier) SetFieldValue(entity interface{}, name string, value refle
 		return nil
 	case reflect.String:
 		if err := reflections.SetField(entity, name, value.String()); err != nil {
+			fmt.Println(entity)
 			return err
 		}
 		return nil

--- a/deepcopier.go
+++ b/deepcopier.go
@@ -306,7 +306,6 @@ func (dc *DeepCopier) SetFieldValue(entity interface{}, name string, value refle
 		return nil
 	case reflect.String:
 		if err := reflections.SetField(entity, name, value.String()); err != nil {
-			fmt.Println(entity)
 			return err
 		}
 		return nil

--- a/deepcopier.go
+++ b/deepcopier.go
@@ -204,6 +204,11 @@ func (dc *DeepCopier) SetField(options *FieldOptions) error {
 func (dc *DeepCopier) SetFieldValue(entity interface{}, name string, value reflect.Value) error {
 	kind := value.Kind()
 
+	if kind == reflect.Ptr {
+		value = value.Elem()
+		kind = value.Kind()
+	}
+
 	// Maps
 	if kind == reflect.Map {
 		switch v := value.Interface().(type) {

--- a/deepcopier_test.go
+++ b/deepcopier_test.go
@@ -8,15 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCopyTo(t *testing.T) {
+func ATestCopyTo(t *testing.T) {
 	is := assert.New(t)
 	now := time.Now()
+	pointer := "pointer"
 
-	user := NewUser(now)
+	user := NewUser(now, &pointer)
 	userCopy := &UserCopy{}
 	userCopyExtended := &UserCopyExtended{}
-	expectedUserCopy := NewUserCopy(now)
-	expectedUserCopyExtended := NewUserCopyExtended(now)
+	expectedUserCopy := NewUserCopy(now, &pointer)
+	expectedUserCopyExtended := NewUserCopyExtended(now, &pointer)
 
 	is.Nil(Copy(user).WithContext(map[string]interface{}{"version": "1"}).To(userCopy))
 
@@ -88,11 +89,12 @@ func TestCopyTo(t *testing.T) {
 func TestCopyFrom(t *testing.T) {
 	is := assert.New(t)
 	now := time.Now()
+	pointer := "pointer"
 
 	user := &User{}
-	userExpected := NewUser(now)
-	userCopy := NewUserCopy(now)
-	userCopyExtended := NewUserCopyExtended(now)
+	userExpected := NewUser(now, &pointer)
+	userCopy := NewUserCopy(now, &pointer)
+	userCopyExtended := NewUserCopyExtended(now, &pointer)
 
 	is.Nil(Copy(user).From(userCopy))
 
@@ -155,9 +157,10 @@ type User struct {
 	AStringSlice []string
 	AnIntSlice   []int
 	ANullString  null.String
+	APointer     string
 }
 
-func NewUser(now time.Time) *User {
+func NewUser(now time.Time, pointer *string) *User {
 	return &User{
 		Name:         "Chuck Norris",
 		Date:         now,
@@ -176,6 +179,7 @@ func NewUser(now time.Time) *User {
 		AStringSlice: []string{"Chuck", "Norris"},
 		AnIntSlice:   []int{0, 8, 15},
 		ANullString:  null.StringFrom("I'm null"),
+		APointer:     *pointer,
 	}
 }
 
@@ -265,13 +269,14 @@ type UserCopy struct {
 	UInt64Method      uint64      `json:"uint64_method"`
 	MethodWithContext string      `json:"method_with_context" deepcopier:"context"`
 	SuperMethod       string      `json:"super_method" deepcopier:"field:MethodWithDifferentName"`
+	PointerString     *string     `json:"a_pointer_string" deepcopier:"field:APointer"`
 }
 
 type UserCopyExtended struct {
 	UserCopy
 }
 
-func NewUserCopy(now time.Time) *UserCopy {
+func NewUserCopy(now time.Time, pointer *string) *UserCopy {
 	return &UserCopy{
 		Title:             "Chuck Norris",
 		Date:              now,
@@ -302,11 +307,12 @@ func NewUserCopy(now time.Time) *UserCopy {
 		UInt64Method:      uint64(10),
 		MethodWithContext: "1",
 		SuperMethod:       "hello",
+		PointerString:     pointer,
 	}
 }
 
-func NewUserCopyExtended(now time.Time) *UserCopyExtended {
+func NewUserCopyExtended(now time.Time, pointer *string) *UserCopyExtended {
 	return &UserCopyExtended{
-		UserCopy: *NewUserCopy(now),
+		UserCopy: *NewUserCopy(now, pointer),
 	}
 }


### PR DESCRIPTION
I added a feature described on title.
For example,
`type To struct {
    Name string
}`
`type From struct {
   Name *string
}`
The value of From's Name can be copied into To's Name.